### PR TITLE
finish initial webpack and electron configuration

### DIFF
--- a/main/electron.js
+++ b/main/electron.js
@@ -3,18 +3,19 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 
+// electron reloader documentation recommends using a try/catch block to avoid
+// crashin the app is node environment is in production
 try {
   const electronReloader = require('electron-reloader');
   electronReloader(module, {
     ignore: [
-      __dirname
+      path.join(__dirname, '..', 'src')
     ]
   });
 } catch {
   console.log('electron reloader failed');
 };
 
-// console.log(path.join(__dirname, '..', 'dist', 'index.html'));
 
 const createWindow = () => {
   // create a browser window

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "jest --verbose",
     "build": "webpack --config ./webpack.config.js --watch",
-    "start": "electron src/electron.js"
+    "start": "npm run build & electron main/electron.js && fg"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,18 +3,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 
 module.exports = [
-  // {
-  //   mode: 'development',
-  //   entry: path.join(__dirname, 'src', 'electron.js'),
-  //   target: 'electron-main',
-  //   output: {
-  //     path: path.join(__dirname, 'dist'),
-  //     filename: 'electron.js'
-  //   },
-  //   // plugins: [
-  //   //   new HtmlWebpackPlugin()
-  //   // ]
-  // },
   {
     mode: 'development',
     entry: path.join(__dirname, 'src', 'react.jsx'),


### PR DESCRIPTION
Some small changes to configuration. The main one is that a single script now boots both webpack compiler and watcher and electron and its watcher and a single control-c cancels both processes.